### PR TITLE
Game output formatting

### DIFF
--- a/bin/tic_tac_toe.rb
+++ b/bin/tic_tac_toe.rb
@@ -8,9 +8,9 @@ require_relative '../lib/console'
 require_relative '../lib/prompt'
 require_relative '../lib/player_selection'
 
+console = Console.new
 loop do
   board = Board.new
-  console = Console.new
   player_one, player_two = Players.select(console)
   game = Game.new(board, player_one, player_two)
   until game.game_over?

--- a/lib/console.rb
+++ b/lib/console.rb
@@ -4,16 +4,16 @@ class Console
     @output = output
   end
 
-  def output(string)
-    @output.print(string)
-  end
-
   def print(string)
     @output.print(string)
   end
 
   def puts(string)
-    @output.puts(string)
+    @output.print(string + "\n")
+  end
+
+  def line_break
+    @output.puts
   end
 
   def get_string

--- a/lib/console.rb
+++ b/lib/console.rb
@@ -8,6 +8,14 @@ class Console
     @output.print(string)
   end
 
+  def print(string)
+    @output.print(string)
+  end
+
+  def puts(string)
+    @output.puts(string)
+  end
+
   def get_string
     @input.gets.chomp
   end

--- a/lib/human.rb
+++ b/lib/human.rb
@@ -18,7 +18,7 @@ class Human
 
   private
     def display_board(board)
-      @console.output BoardDisplay.as_string(board)
+      @console.puts(BoardDisplay.as_string(board))
     end
  
     def get_empty_space(board)

--- a/lib/player_selection.rb
+++ b/lib/player_selection.rb
@@ -11,14 +11,15 @@ class Players
       name_one = get_name("one", console)
       name_two = get_name("two", console)
       until name_one != name_two do
-        console.output("Players cannot have the same name\n")
+        console.puts("Players cannot have the same name")
         name_two = get_name("two", console)
       end
+      console.line_break
       [name_one, name_two]
     end
 
     def self.get_name(player_num, console)
-      console.output("Enter player #{player_num} name: ")
+      console.print("Enter player #{player_num} name: ")
       console.get_string
     end
 end

--- a/lib/prompt.rb
+++ b/lib/prompt.rb
@@ -2,18 +2,20 @@ class Prompt
   def self.for_int_in_range(console, message, range)
     int = nil
     until range.include?(int)
-      console.output("#{message} (#{range.first}-#{range.last}): ")
+      console.print("#{message} (#{range.first}-#{range.last}): ")
       int = console.get_int
     end
+    console.line_break
     int
   end
   
   def self.play_again?(console)
     answer = nil
     until answer == "y" || answer == "n" do
-      console.output("Do you want to play another game? (y/n): ")
+      console.print("Do you want to play another game? (y/n): ")
       answer = console.get_string
     end
+    console.line_break
     answer == "y"
   end
 end

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -5,13 +5,14 @@ class Result
     if !board.game_over?
       raise(ArgumentError, "Board is not in game over state")
     end
-    console.output(BoardDisplay.as_string(board))
+    console.puts(BoardDisplay.as_string(board))
     if board.drawn?
       message = "It's a draw. Players are evenly matched"
     else
       winning_mark = board.winning_mark
       message = "#{winning_mark} wins! Congrats #{winning_mark}"
     end
-    console.output(message + "\n")
+    console.puts(message)
+    console.line_break
   end
 end

--- a/spec/console_spec.rb
+++ b/spec/console_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe Console do
       expect(output.string).to eq test_string
     end
   end
+
+  describe "#print" do
+    it "writes input string to output" do
+      test_string = "Parzival!"
+      console.print(test_string)
+      expect(output.string).to eq test_string
+    end
+  end
+
+  describe "#puts" do
+    it "writes input string to output adding newline" do
+      test_string = "Parzival!"
+      console.puts(test_string)
+      expect(output.string).to eq test_string + "\n"
+    end
+  end
   
   describe "#get_string" do
     it "gets string from input" do

--- a/spec/console_spec.rb
+++ b/spec/console_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe Console do
   let(:output) { StringIO.new }
   let(:console) { Console.new(input, output) }
 
-  describe "#output" do
-    it "writes input string to output" do
-      test_string = "Parzival!"
-      console.output(test_string)
-      expect(output.string).to eq test_string
-    end
-  end
-
   describe "#print" do
     it "writes input string to output" do
       test_string = "Parzival!"
@@ -27,6 +19,19 @@ RSpec.describe Console do
       test_string = "Parzival!"
       console.puts(test_string)
       expect(output.string).to eq test_string + "\n"
+    end
+
+    it "adds newline even if one already present" do
+      test_string = "Parzival!\n"
+      console.puts(test_string)
+      expect(output.string).to eq test_string + "\n"
+    end
+  end
+
+  describe "#line_break" do
+    it "outputs newline" do
+      console.line_break
+      expect(output.string).to eq "\n"
     end
   end
   

--- a/spec/human_spec.rb
+++ b/spec/human_spec.rb
@@ -2,7 +2,7 @@ require 'human'
 require 'board'
 
 RSpec.describe Human do
-  let(:console) { instance_double("Console", { :get_int => 5, :output => nil}) }
+  let(:console) { instance_double("Console", { :get_int => 5, :puts => nil, :print => nil, :line_break => nil}) }
   let(:player) { Human.new("X", "Tyrion", console) }
   let(:board) { Board.new }
   let(:expected_prompt) { "[Tyrion] Choose space (1-9): " }
@@ -17,12 +17,12 @@ RSpec.describe Human do
                      "|---|---|---|\n" +
                      "| 7 | 8 | 9 |\n" +
                      "|---|---|---|\n"
-      expect(console).to receive(:output).with(board_output)
+      expect(console).to receive(:puts).with(board_output)
       player.choose_space(board)
     end
 
     it "prompts for space" do
-      expect(console).to receive(:output).with(expected_prompt)
+      expect(console).to receive(:print).with(expected_prompt)
       player.choose_space(board)
     end
 
@@ -35,7 +35,7 @@ RSpec.describe Human do
     context "when input space is not in range" do
       it "prompts again" do
         allow(console).to receive(:get_int).and_return(-1, 0, 10, 5)
-        expect(console).to receive(:output).with(expected_prompt).exactly(4).times
+        expect(console).to receive(:print).with(expected_prompt).exactly(4).times
         player.choose_space(board)
       end
 
@@ -49,7 +49,7 @@ RSpec.describe Human do
       it "prompts again" do
         board.set_mark(1, "X")
         allow(console).to receive(:get_int).and_return(1, 5)
-        expect(console).to receive(:output).with(expected_prompt).exactly(2).times
+        expect(console).to receive(:print).with(expected_prompt).exactly(2).times
         player.choose_space(board)
       end
 

--- a/spec/player_selection_spec.rb
+++ b/spec/player_selection_spec.rb
@@ -4,7 +4,7 @@ require 'console'
 describe Players do
   describe ".select" do
     before(:each) do
-      @console = instance_double("Console", :output => nil)
+      @console = instance_double("Console", :print => nil, :puts => nil, :line_break => nil)
       allow(@console).to receive(:get_string).and_return("Tyrion", "Cersei")
     end
 
@@ -30,7 +30,7 @@ describe Players do
     it "prompts players for names" do
       ["one", "two"].each do |num|
         prompt = "Enter player #{num} name: "
-        expect(@console).to receive(:output).with(prompt).ordered
+        expect(@console).to receive(:print).with(prompt).ordered
         expect(@console).to receive(:get_string).ordered
       end
       Players.select(@console)
@@ -47,9 +47,15 @@ describe Players do
     end
 
     context "when player two inputs same name as player one" do
+      it "outputs error" do
+        allow(@console).to receive(:get_string).and_return("Tyrion", "Tyrion", "Cersei")
+        expect(@console).to receive(:puts).with("Players cannot have the same name")
+        Players.select(@console)
+      end
+
       it "prompts for name again" do
         allow(@console).to receive(:get_string).and_return("Tyrion", "Tyrion", "Cersei")
-        expect(@console).to receive(:output).with(/Enter player two/).exactly(2).times
+        expect(@console).to receive(:print).with(/Enter player two/).exactly(2).times
         expect(@console).to receive(:get_string).exactly(3).times
         Players.select(@console)
       end

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -4,13 +4,13 @@ require 'console'
 RSpec.describe Prompt do
 
   describe ".for_int_in_range" do
-    let(:console) { instance_double("Console", { :get_int => 3, :output => nil}) }
+    let(:console) { instance_double("Console", { :get_int => 3, :print => nil, :puts => nil, :line_break => nil}) }
     let(:message) { "Choose space" }
     let(:range) { (1..9) }
     let(:expected_message) { "Choose space (1-9): " }
 
     it "outputs message" do
-      expect(console).to receive(:output).with(expected_message)
+      expect(console).to receive(:print).with(expected_message)
       Prompt.for_int_in_range(console, message, range)
     end
 
@@ -23,7 +23,7 @@ RSpec.describe Prompt do
     context "when player enters integer outside range" do
       it "outputs message again" do
         allow(console).to receive(:get_int).and_return(10, 5)
-        expect(console).to receive(:output).with(expected_message).twice
+        expect(console).to receive(:print).with(expected_message).twice
         Prompt.for_int_in_range(console, message, range)
       end
     end
@@ -31,10 +31,10 @@ RSpec.describe Prompt do
 
   describe ".play_again?" do
     let(:yes_answer) { "y" }
-    let(:console) { instance_double("Console", { :get_string => yes_answer, :output => nil }) }
+    let(:console) { instance_double("Console", { :get_string => yes_answer, :print => nil, :puts => nil, :line_break => nil}) }
 
     it "outputs question" do
-      expect(console).to receive(:output).with("Do you want to play another game? (y/n): ")
+      expect(console).to receive(:print).with("Do you want to play another game? (y/n): ")
       Prompt.play_again?(console)
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Prompt do
         it "outputs question again" do
           allow(console).to receive(:get_string).and_return(answer, yes_answer)
           Prompt.play_again?(console)
-          expect(console).to have_received(:output).twice
+          expect(console).to have_received(:print).twice
         end
 
         it "returns eventual valid answer" do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -3,7 +3,7 @@ require 'board'
 require 'console'
 
 describe "Result.display" do
-  let(:console) { instance_double("Console", :output => nil) }
+  let(:console) { instance_double("Console", :puts => nil, :line_break => nil) }
   let(:drawn_board) { board = Board.from_a(["X", "X", "Y",
                                             "Y" ,"Y", "X",
                                             "X", "X", "Y"]) }
@@ -13,14 +13,14 @@ describe "Result.display" do
       board = Board.from_a(["X", "X", "X",
                             "Y", "Y", "",
                              "", "", ""])
-      expect(console).to receive(:output).with("X wins! Congrats X\n")
+      expect(console).to receive(:puts).with("X wins! Congrats X")
       Result.display(board, console)
     end
   end
 
   context "when board is drawn" do
     it "outputs draw message" do
-      expect(console).to receive(:output).with("It's a draw. Players are evenly matched\n")
+      expect(console).to receive(:puts).with("It's a draw. Players are evenly matched")
       Result.display(drawn_board, console)
     end
   end
@@ -40,7 +40,7 @@ describe "Result.display" do
                    "|---|---|---|\n" +
                    "| X | X | Y |\n" +
                    "|---|---|---|\n"
-    expect(console).to receive(:output).with(board_output)
+    expect(console).to receive(:puts).with(board_output)
     Result.display(drawn_board, console)
   end
 end


### PR DESCRIPTION
Currently all elements in game appear one line after the other which is not very attractive. This change spaces elements out with line breaks.

In order to better support formatting have updated Console class methods, replacing "output" with "print/puts/line_break".

@indykid @maikon