### PR TITLE
4x4 computer optimisation

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,4 +1,5 @@
 require_relative 'board'
+require_relative 'zobrist_hash'
 
 class Board
   attr_reader :size
@@ -8,15 +9,18 @@ class Board
     @dimension = dimension
     @size = dimension*dimension
     @board = Array.new(@size, "")
+    @state_hash = ZobristHash.with_random_bit_strings()
   end
 
   def set_mark(space, mark)
     validate_space(space)
+    @state_hash.update(space, mark)
     @board[space-1] = mark
   end
 
   def remove_mark(space)
     validate_space(space)
+    @state_hash.update(space, @board[space-1])
     @board[space-1] = ""
   end
 
@@ -68,6 +72,10 @@ class Board
       board.set_mark(space, mark)
     end
     board
+  end
+
+  def state_hash
+    @state_hash.get()
   end
   
   private

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -10,17 +10,21 @@ class Board
     @size = dimension*dimension
     @board = Array.new(@size, "")
     @state_hash = ZobristHash.with_random_bit_strings()
+    @spaces_marked = 0
+    @min_spaces_for_win = dimension*2 - 1
   end
 
   def set_mark(space, mark)
     validate_space(space)
     @state_hash.update(space, mark)
+    @spaces_marked += 1
     @board[space-1] = mark
   end
 
   def remove_mark(space)
     validate_space(space)
     @state_hash.update(space, @board[space-1])
+    @spaces_marked -= 1
     @board[space-1] = ""
   end
 
@@ -30,6 +34,9 @@ class Board
   end
 
   def game_over?
+    if @spaces_marked < @min_spaces_for_win
+      return false
+    end
     winning_line_present? || all_spaces_taken?
   end
 
@@ -68,8 +75,10 @@ class Board
   def self.from_a(marks)
     board = Board.new
     marks.each_with_index do |mark, index|
-      space = index + 1
-      board.set_mark(space, mark)
+      if !mark.empty?
+        space = index + 1
+        board.set_mark(space, mark)
+      end
     end
     board
   end
@@ -118,6 +127,6 @@ class Board
     end
 
     def all_spaces_taken?
-      @board.all? { |mark| !mark.empty? }
+      @spaces_marked == @size 
     end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -4,7 +4,8 @@ require_relative 'zobrist_hash'
 class Board
   attr_reader :size
   attr_reader :dimension
-  
+  attr_reader :spaces_marked 
+
   def initialize(dimension = 3) 
     @dimension = dimension
     @size = dimension*dimension

--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -21,6 +21,21 @@ class Computer
     Move = Struct.new(:space, :value)
 
     def get_space(board)
+      if opening_moves?(board)
+        return first_available_space(board)
+      end
+      strategic_space(board)
+    end
+
+    def opening_moves?(board)
+      (board.dimension > 3) && (board.spaces_marked <= board.dimension)
+    end
+
+    def first_available_space(board)
+      board.empty_spaces().first()
+    end
+
+    def strategic_space(board)
       moves = board.empty_spaces.collect { |space| Move.new(space, value_of_move(board, space)) }
       best_move = moves.max { |a, b| a.value <=> b.value }
       best_move.space

--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -8,6 +8,7 @@ class Computer
     @mark = mark
     @name = name
     @console = console
+    @transposition_table = {}
   end
 
   def choose_space(board)
@@ -27,7 +28,7 @@ class Computer
 
     def value_of_move(board, space)
       Board.with_move(board, space, @mark) do
-        -Negamax.value_to_mark(Mark.opponent(@mark), board)
+        -Negamax.value_to_mark(Mark.opponent(@mark), board, @transposition_table)
       end
     end 
     

--- a/lib/zobrist_hash.rb
+++ b/lib/zobrist_hash.rb
@@ -1,4 +1,12 @@
 class ZobristHash
+  FIXNUM_MAX = (2**(0.size * 8 -2) -1)
+
+  @@bit_strings = Array.new(32) { Random.rand(FIXNUM_MAX) }
+  
+  def self.with_random_bit_strings
+    new(@@bit_strings)
+  end
+
   def initialize(bit_strings)
     @bit_strings = bit_strings
     @mark_index = bit_strings.length / 2

--- a/lib/zobrist_hash.rb
+++ b/lib/zobrist_hash.rb
@@ -1,0 +1,21 @@
+class ZobristHash
+  def initialize(bit_strings)
+    @bit_strings = bit_strings
+    @mark_index = bit_strings.length / 2
+    @hash = 0
+  end
+
+  def get
+    @hash 
+  end
+
+  def update(space, mark)
+    @hash = @hash ^ @bit_strings[index_for(space ,mark)]
+  end
+
+  private
+    def index_for(space, mark)
+      mark_modifier = (mark == "X") ? 0 : 1
+      mark_modifier*@mark_index + space-1 
+    end
+end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -190,4 +190,38 @@ RSpec.describe Board do
       end
     end
   end
+
+  describe "#state_hash" do
+    it "returns same value for boards in same state" do
+      board_state = ["X", "O", "",
+                     "X", "", "",
+                     "O", "", "X"]
+      board = Board.from_a(board_state)
+      other_board = Board.from_a(board_state)
+      expect(board.state_hash()).to eq other_board.state_hash()
+    end
+
+    it "returns different value for boards in different state" do
+        board = Board.from_a(["X", "", "O",
+                               "", "X", "",
+                              "O", "X", ""])
+        other_board = Board.from_a(["X", "", "O",
+                                     "", "X", "",
+                                    "O", "", ""])
+        expect(board.state_hash()).not_to eq other_board.state_hash()
+    end
+
+    it "returns same value for boards in same state regardless of how they got there" do
+        board = Board.new
+        board.set_mark(5, "X")
+        board.set_mark(9, "O")
+
+        other_board = Board.new
+        other_board.set_mark(6, "X")
+        other_board.set_mark(9, "O")
+        other_board.set_mark(5, "X")
+        other_board.remove_mark(6)
+        expect(board.state_hash()).to eq other_board.state_hash()
+    end
+  end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Board do
       context "when player has taken all of line #{line}" do
         it "returns true" do
           line.each { |space| board.set_mark(space, "X") }
+          board.empty_spaces.take(2).each { |space| board.set_mark(space, "O") }
           expect(board.game_over?).to be true
         end
       end

--- a/spec/computer_spec.rb
+++ b/spec/computer_spec.rb
@@ -47,13 +47,15 @@ RSpec.describe Computer do
 
   describe "full game" do
     let(:other_computer) { Computer.new("O", "Rickon", console) }
-    let(:board) { Board.new }
 
-    context "when computer is playing computer" do
-      it "ends in draw" do
-        Game.play(board, computer, other_computer)
-        expect(board.drawn?).to be true 
-      end 
+    [3, 4].each do |dimension|
+      context "when computer is playing computer with board dimension #{dimension}" do
+        it "ends in draw" do
+          board = Board.new(dimension)
+          Game.play(board, computer, other_computer)
+          expect(board.drawn?).to be true 
+        end 
+      end
     end
   end
 end

--- a/spec/negamax_spec.rb
+++ b/spec/negamax_spec.rb
@@ -2,39 +2,41 @@ require 'negamax'
 require 'board'
 
 RSpec.describe Negamax do
+  let(:transposition_table) { {} }
+
   it "returns maximum value when board is won for mark" do
     board = Board.from_a(["X", "X", "X",
                           "O", "O", "",
                            "", "", ""])
-    expect(Negamax.value_to_mark("X", board)).to eq Negamax::MAX_VALUE
+    expect(Negamax.value_to_mark("X", board, transposition_table)).to eq Negamax::MAX_VALUE
   end
 
   it "returns negative of maximum value when board is lost for mark" do
     board = Board.from_a(["X", "X", "X",
                           "O", "O", "",
                            "", "", ""])
-    expect(Negamax.value_to_mark("O", board)).to eq -Negamax::MAX_VALUE
+    expect(Negamax.value_to_mark("O", board, transposition_table)).to eq -Negamax::MAX_VALUE
   end
 
   it "returns zero when board is drawn" do
     board = Board.from_a(["X", "X", "O",
                           "O", "X", "X",
                           "X", "O", "O"])
-    expect(Negamax.value_to_mark("X", board)).to eq 0
-    expect(Negamax.value_to_mark("O", board)).to eq 0 
+    expect(Negamax.value_to_mark("X", board, transposition_table)).to eq 0
+    expect(Negamax.value_to_mark("O", board, transposition_table)).to eq 0 
   end
 
   it "subtracts number of marks needed to end game from winning score" do
     board = Board.from_a(["X", "X", "",
                           "O", "O", "",
                            "", "", ""])
-    expect(Negamax.value_to_mark("X", board)).to eq Negamax::MAX_VALUE - 1
+    expect(Negamax.value_to_mark("X", board, transposition_table)).to eq Negamax::MAX_VALUE - 1
   end
 
   it "add number of marks needed to end game to losing score" do
     board = Board.from_a(["", "", "O",
                           "O", "X", "",
                           "X", "", "X"])
-    expect(Negamax.value_to_mark("O", board)).to eq -Negamax::MAX_VALUE + 2
+    expect(Negamax.value_to_mark("O", board, transposition_table)).to eq -Negamax::MAX_VALUE + 2
   end
 end

--- a/spec/zobrist_hash_spec.rb
+++ b/spec/zobrist_hash_spec.rb
@@ -1,0 +1,29 @@
+require 'zobrist_hash'
+
+RSpec.describe ZobristHash do
+  let(:bit_strings) { (1..32).to_a }
+  let(:zobrist_hash) { ZobristHash.new(bit_strings) }
+
+  it "initially returns 0" do
+    expect(zobrist_hash.get()).to eq 0
+  end
+
+  it "updates hash based on bitstrings" do
+    zobrist_hash.update(1, "X")
+    zobrist_hash.update(9, "X")
+    # 01 ^ 11 = 10
+    expect(zobrist_hash.get()).to eq 8
+  end
+
+  it "updates using different bitstrings for each mark" do
+    zobrist_hash.update(1, "O")
+    expect(zobrist_hash.get()).to eq 17
+  end
+
+  it "reverses an update when applied again" do
+    zobrist_hash.update(1, "X")
+    zobrist_hash.update(9, "X")
+    zobrist_hash.update(1, "X")
+    expect(zobrist_hash.get()).to eq 9
+  end
+end


### PR DESCRIPTION
Update to ensure computer player still responds in reasonable time for 4x4 board. This involves

- Transposition tables using zobrist hash to improve negamax calculation time
- Improvement to board game over check (which is hit by negamax a lot)
- Bootstrapping the opening moves of the game to just return first available space. This is not really any different result wise to negamax but means the initial search space is reduced once we hit it

@indykid @maikon